### PR TITLE
Improve Safari plugin options

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,7 +1,8 @@
 Packaging version [18.09](https://github.com/open-eid/osx-installer/releases/tag/v18.09) release notes
 --------------------------------------------
-- Add safari-token-signing
+- Add safari-token-signing on macOS >= 10.12
 - Use esteid-ctk-tokend for all cards on macOS >= 10.12
+- Remove legacy NPAPI plugin from macOS >= 10.14
 
 [Full Changelog](https://github.com/open-eid/osx-installer/compare/v18.06...v18.09)
 

--- a/distribution.xml
+++ b/distribution.xml
@@ -163,6 +163,14 @@ function pm_safari_selected() {
      my.target.receiptForIdentifier("ee.ria.firefox-token-signing") != null);
 }
 
+function pm_safari_old_enabled() {
+  return system.compareVersions(system.version.ProductVersion, '10.14') < 0;
+}
+
+function pm_safari_new_enabled() {
+  return system.compareVersions(system.version.ProductVersion, '10.12') >= 0;
+}
+
 function pm_firefox_selected() {
   return my.target.receiptForIdentifier("ee.ria.open-eid") == null ||
     my.target.receiptForIdentifier("ee.ria.firefox-pkcs11-loader") != null;
@@ -188,14 +196,6 @@ function pm_drivers_new_enabled() {
   return system.compareVersions(system.version.ProductVersion, '10.12') >= 0;
 }
 
-function pm_drivers_old_selected() {
-  return pm_drivers_old_enabled() && pm_drivers_selected();
-}
-
-function pm_drivers_new_selected() {
-  return pm_drivers_new_enabled() && pm_drivers_selected();
-}
-
 ]]>
     </script>
     <choices-outline>
@@ -203,30 +203,26 @@ function pm_drivers_new_selected() {
         <line choice="safari"/>
         <line choice="firefox"/>
         <line choice="chrome"/>
-        <line choice="drivers_old"/>
-        <line choice="drivers_new"/>
+        <line choice="drivers"/>
     </choices-outline>
     <choice id="default" title="SU_BASE" start_enabled="false" visible="false">
         <pkg-ref id="ee.ria.updater">updater.pkg</pkg-ref>
         <pkg-ref id="ee.ria.open-eid">Open-EID.pkg</pkg-ref>
     </choice>
     <choice id="safari" title="SU_SAFARI" description="SU_SAFARI" start_selected="pm_safari_selected()">
-        <pkg-ref id="ee.ria.safari-token-signing">safari-token-signing.pkg</pkg-ref>
-        <pkg-ref id="ee.ria.firefox-token-signing">firefox-token-signing.pkg</pkg-ref>
+        <pkg-ref id="ee.ria.safari-token-signing" active="pm_safari_new_enabled()">safari-token-signing.pkg</pkg-ref>
+        <pkg-ref id="ee.ria.firefox-token-signing" active="pm_safari_old_enabled()">firefox-token-signing.pkg</pkg-ref>
     </choice>
     <choice id="firefox" title="SU_FIREFOX" description="SU_FIREFOX" start_selected="pm_firefox_selected()">
-        <pkg-ref id="ee.ria.chrome-token-signing">chrome-token-signing.pkg</pkg-ref>
+        <pkg-ref id="ee.ria.chrome-token-signing"/>
         <pkg-ref id="ee.ria.firefox-pkcs11-loader">firefox-pkcs11-loader.pkg</pkg-ref>
     </choice>
     <choice id="chrome" title="SU_CHROME" description="SU_CHROME" start_selected="pm_chrome_selected()">
         <pkg-ref id="ee.ria.chrome-token-signing">chrome-token-signing.pkg</pkg-ref>
     </choice>
-    <choice id="drivers_old" title="SU_DRIVERS" description="SU_DRIVERS" start_selected="pm_drivers_old_selected()" start_enabled="pm_drivers_old_enabled()">
+    <choice id="drivers" title="SU_DRIVERS" description="SU_DRIVERS" start_selected="pm_drivers_selected()">
         <pkg-ref id="org.opensc-project.mac">opensc.pkg</pkg-ref>
-        <pkg-ref id="ee.ria.esteid-tokend">esteid-tokend.pkg</pkg-ref>
-    </choice>
-    <choice id="drivers_new" title="SU_DRIVERS" description="SU_DRIVERS" start_selected="pm_drivers_new_selected()" start_enabled="pm_drivers_new_enabled()">
-        <pkg-ref id="org.opensc-project.mac">opensc.pkg</pkg-ref>
-        <pkg-ref id="ee.ria.esteid-ctk-tokend">esteid-ctk-tokend.pkg</pkg-ref>
+        <pkg-ref id="ee.ria.esteid-ctk-tokend" active="pm_drivers_new_enabled()">esteid-ctk-tokend.pkg</pkg-ref>
+        <pkg-ref id="ee.ria.esteid-tokend" active="pm_drivers_old_enabled()">esteid-tokend.pkg</pkg-ref>
     </choice>
 </installer-gui-script>

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -14,5 +14,6 @@ defaults write /Library/Preferences/ee.ria.qdigidoc4 plugins "${version}"
 
 #/usr/bin/open 'http://appstore.com/mac/ria'
 /usr/bin/open "macappstores://search.itunes.apple.com/WebObjects/MZContentLink.woa/wa/link?mt=12&path=mac%2fria"
+/usr/bin/open /Applications/Utilities/TokenSigningApp.app
 
 exit 0


### PR DESCRIPTION
Install NPAPI only on macOS < 10.14
Install Safari Extension on macOS > 10.12
Open Safari preferences after install to allow enable extension

IB-5478, IB-5480, IB-5483

Signed-off-by: Raul Metsma <raul@metsma.ee>